### PR TITLE
Hide 'Contact' post type from front-end queries

### DIFF
--- a/custom-posttypes.php
+++ b/custom-posttypes.php
@@ -960,6 +960,7 @@ class Contact extends CustomPostType {
 		// Optional default ordering for generic shortcode if not specified by user.
 		$default_orderby = null,
 		$default_order   = null,
+		$publicly_queryable  = false, // Disable front-end view of this post type
 
 		$calculated_columns = array(), // Calculate values within custom_column_echo_data.
 		$sc_interface_fields = null; // Fields for shortcodebase interface (false hides from list, null shows only the default fields).

--- a/functions/class-custom-posttype.php
+++ b/functions/class-custom-posttype.php
@@ -61,7 +61,8 @@ abstract class CustomPostType {
 		array( 'heading' => 'Thumbnail', 'column_name' => '_thumbnail_id', 'order' => 100, 'sortable' => false ),
 		// array( 'heading'=>'A Column Heading Text', 'column_name'=>'id_of_the_column', 'order' => 1000 'sortable' => true ),
 	), // Calculate values within custom_column_echo_data.
-	$sc_interface_fields = null; // Fields for shortcodebase interface (false hides from list, null shows only the default fields).
+	$sc_interface_fields = null, // Fields for shortcodebase interface (false hides from list, null shows only the default fields).
+	$publicly_queryable  = true; // Whether the front end can query this post type
 
 	/**
 	 * Wrapper for get_posts function, that predefines post_type for this
@@ -410,7 +411,7 @@ abstract class CustomPostType {
 	 * @see http://codex.wordpress.org/Function_Reference/register_post_type WP-Codex: register_post_type()
 	 * @see http://codex.wordpress.org/Function_Reference/add_shortcode WP-Codex: add_shortcode()
 	 * @uses labels(), supports(), options(), custom_columns_get_all(), register_custom_columns()
-	 * @uses $public, $taxonomies, $built_in, $use_order, $name, $use_shortcode
+	 * @uses $public, $taxonomies, $built_in, $use_order, $name, $use_shortcode, $publicly_queryable
 	 * @param Array $args Override the registration args passed to register_post_type.
 	 * */
 	public function register( $args = array() ) {
@@ -422,6 +423,7 @@ abstract class CustomPostType {
 			'taxonomies' => $this->options( 'taxonomies' ),
 			'_builtin'   => $this->options( 'built_in' ),
 			'menu_icon'  => $this->options( 'menu_icon' ),
+			'publicly_queryable' => $this->options( 'publicly_queryable' ),
 			);
 		if ( $this->options( 'use_order' ) ) {
 			$registration = array_merge( $registration, array( 'hierarchical' => true ) );


### PR DESCRIPTION
Added 'publicly_queryable' parameter to CustomPostType class. Default is true.
Users were finding (blank) pages for single Contact posts from Google searches.