### PR TITLE
Fix: Back button shortcode outputs before post body

### DIFF
--- a/shortcodes.php
+++ b/shortcodes.php
@@ -910,11 +910,14 @@ class sc_backButton extends ShortCodeBase {
 		} else {
 			$url = get_home_url();
 		}
+		ob_start();
 		?>
 
 		<a class="btn btn-callout float-right mt-3" href="<?= $url ?>">< Back</a>
 
 		<?php
+		return ob_get_clean();
+
 	}
 }
 


### PR DESCRIPTION
I mistakenly output the shortcode content directly from the function rather than returning it.
I only tested it on simple pages so I missed this error.