### PR TITLE
Define new custom taxonomy for record archives

### DIFF
--- a/custom-posttypes.php
+++ b/custom-posttypes.php
@@ -1156,7 +1156,7 @@ class Records extends CustomPostType {
 	$use_order      = false,
 	$use_metabox    = true,  
 	$use_shortcode  = true,
-	$taxonomies     = array( 'post_tag', 'org_groups' ),
+	$taxonomies     = array( 'arc_groups' ),
 	$menu_icon      = 'dashicons-media-text',
 	$built_in       = false;
 

--- a/custom-taxonomies.php
+++ b/custom-taxonomies.php
@@ -32,10 +32,33 @@ class OrganizationalGroups extends CustomTaxonomy
 	$hierarchical       = True;
 } // END class 
 
+/**
+ * Describes archival storage groups for Records
+ */
+class ArchivalGroups extends CustomTaxonomy
+{
+	public
+	$name               = 'arc_groups',
+	$general_name       = 'Archival Groups',
+	$singular_name      = 'Archival Group',
+	$search_items       = 'Search Archival Groups',
+	$popular_items      = 'Popular Archival Groups',
+	$all_times          = 'All Archival Groups',
+	$parent_item        = 'Parent Archival Group',
+	$parent_item_colon  = 'Parent Archival Group:',
+	$edit_item          = 'Edit Archival Group',
+	$update_item        = 'Update Archival Group',
+	$add_new_item       = 'Add New Archival Group',
+	$new_item_name      = 'New Tag Archival Group',
+	
+	$show_admin_column  = True,
+	$hierarchical       = True;
+}
 
 function register_custom_taxonomies() {
 	CustomTaxonomy::Register_Taxonomies( array(
 		__NAMESPACE__.'\OrganizationalGroups',
+		__NAMESPACE__.'\ArchivalGroups',
 		));
 }
 add_action('init', __NAMESPACE__.'\register_custom_taxonomies');


### PR DESCRIPTION
Define new custom taxonomy for record archives

There are too many different "folders" records need to be sorted into, it will quickly become a mess to navigate all the groups in the WordPress editor so I defined another custom taxonomy "Archival Groups" for storing Records. Only the Records post type supports this taxonomy.