### PR TITLE
update sticky-top class style

### DIFF
--- a/css/bootstrap.css
+++ b/css/bootstrap.css
@@ -9430,7 +9430,7 @@ a.bg-inverse:hover {
 .sticky-top {
   position: sticky;
   top: 0;
-  z-index: 1030;
+  z-index: 999;
 }
 
 .sr-only {


### PR DESCRIPTION
The original z-index causes the sidebar on the osi events page to clip through the dropdown navbar menu